### PR TITLE
Fix CI after fixing local build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Configure
       run: |
         cd ${{runner.workspace}}\melonDS-Vanguard\melonDS-Vanguard\out\build\x64-Debug
-        cmake .. -DENABLE_LTO=false -DDONT_COPY_FIRMWARE=true -DDONT_BUILD_EXTRA_SDL_CODE=true -DCI_BUILD_SHARED_LIBS=true -DCI_INCLUDE_EXTRA_LIBUI_LIBS=true
+        cmake ..\..\ -DENABLE_LTO=false -DDONT_COPY_FIRMWARE=true -DDONT_BUILD_EXTRA_SDL_CODE=true -DCI_BUILD_SHARED_LIBS=true -DCI_INCLUDE_EXTRA_LIBUI_LIBS=true
     - name: Build melonDS-Vanguard
       run: |
         cd ${{runner.workspace}}\melonDS-Vanguard\melonDS-Vanguard\out\build\x64-Debug

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Configure
       run: |
         cd ${{runner.workspace}}\melonDS-Vanguard\melonDS-Vanguard\out\build\x64-Debug
-        cmake ..\..\ -DENABLE_LTO=false -DDONT_COPY_FIRMWARE=true -DDONT_BUILD_EXTRA_SDL_CODE=true -DCI_BUILD_SHARED_LIBS=true -DCI_INCLUDE_EXTRA_LIBUI_LIBS=true
+        cmake ..\..\..\ -DENABLE_LTO=false -DDONT_COPY_FIRMWARE=true -DDONT_BUILD_EXTRA_SDL_CODE=true -DCI_BUILD_SHARED_LIBS=true -DCI_INCLUDE_EXTRA_LIBUI_LIBS=true
     - name: Build melonDS-Vanguard
       run: |
         cd ${{runner.workspace}}\melonDS-Vanguard\melonDS-Vanguard\out\build\x64-Debug

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,12 +32,12 @@ jobs:
         path: 'melonDS-Vanguard'
     - name: Create build directory
       run: |
-        New-Item -ItemType directory -Path ${{runner.workspace}}\melonDS-Vanguard\melonDS-Vanguard\build
+        New-Item -ItemType directory -Path ${{runner.workspace}}\melonDS-Vanguard\melonDS-Vanguard\out\build\x64-Debug
     - name: Configure
       run: |
-        cd ${{runner.workspace}}\melonDS-Vanguard\melonDS-Vanguard\build
+        cd ${{runner.workspace}}\melonDS-Vanguard\melonDS-Vanguard\out\build\x64-Debug
         cmake .. -DENABLE_LTO=false -DDONT_COPY_FIRMWARE=true -DDONT_BUILD_EXTRA_SDL_CODE=true -DCI_BUILD_SHARED_LIBS=true -DCI_INCLUDE_EXTRA_LIBUI_LIBS=true
     - name: Build melonDS-Vanguard
       run: |
-        cd ${{runner.workspace}}\melonDS-Vanguard\melonDS-Vanguard\build
+        cd ${{runner.workspace}}\melonDS-Vanguard\melonDS-Vanguard\out\build\x64-Debug
         msbuild melonDS.sln


### PR DESCRIPTION
VS cmake creates a different path structure than CI cmake. I reverted the path in https://github.com/NarryG/melonDS-Vanguard/commit/d20867addc9fdcffe84f08f05fe4dbdc3f54a7d3 and this fixes the CI